### PR TITLE
Add auto-save to localStorage and one-click Google Translate

### DIFF
--- a/app/api/translate/route.js
+++ b/app/api/translate/route.js
@@ -1,4 +1,4 @@
-// GET: /api/translate?text=Hello&from=en&to=zh
+// POST: /api/translate { "text": "Hello", "from": "en", "to": "zh" }
 
 /**
  * Direct Google Translate API implementation
@@ -24,24 +24,16 @@ function toGoogleLang(code) {
   return code.split("-")[0];
 }
 
-export default async function handler(req) {
-  return GET(req);
+function badRequest(message) {
+  return new Response(JSON.stringify({ error: message }), {
+    status: 400,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
-export async function GET(req) {
-  const url = new URL(req.url);
-  const text = url.searchParams.get("text");
-  const from = url.searchParams.get("from") || "auto";
-  const to = url.searchParams.get("to") || "en";
-
+async function handleTranslation({ text, from, to }) {
   if (!text) {
-    return new Response(
-      JSON.stringify({ error: "Text parameter is required" }),
-      {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    return badRequest("Text parameter is required");
   }
 
   try {
@@ -53,12 +45,7 @@ export async function GET(req) {
       text
     )}`;
 
-    const response = await fetch(translateUrl, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
-      },
-    });
+    const response = await fetch(translateUrl);
 
     if (!response.ok) {
       throw new Error(`Translation API returned ${response.status}`);
@@ -79,7 +66,7 @@ export async function GET(req) {
         input: text,
         output: translatedText || text,
         from: data.src || from,
-        to,
+        to
       }),
       {
         status: 200,
@@ -91,12 +78,34 @@ export async function GET(req) {
     return new Response(
       JSON.stringify({
         error: "Translation failed",
-        message: error.message,
+        message: error.message
       }),
       {
         status: 500,
         headers: { "Content-Type": "application/json" },
       }
     );
+  }
+}
+
+export async function GET(req) {
+  const url = new URL(req.url);
+  return handleTranslation({
+    text: url.searchParams.get("text"),
+    from: url.searchParams.get("from") || "auto",
+    to: url.searchParams.get("to") || "en",
+  });
+}
+
+export async function POST(req) {
+  try {
+    const body = await req.json();
+    return handleTranslation({
+      text: body?.text,
+      from: body?.from || "auto",
+      to: body?.to || "en",
+    });
+  } catch (error) {
+    return badRequest("Invalid JSON body");
   }
 }

--- a/app/api/translate/route.js
+++ b/app/api/translate/route.js
@@ -1,0 +1,102 @@
+// GET: /api/translate?text=Hello&from=en&to=zh
+
+/**
+ * Direct Google Translate API implementation
+ * Uses translate.googleapis.com/translate_a/single endpoint
+ * This is the same endpoint used by translate.google.com web interface
+ */
+export const runtime = "edge";
+
+// Map Xcode String Catalog language codes to Google Translate format
+const langMap = {
+  "zh-Hans": "zh-CN",
+  "zh-Hant": "zh-TW",
+  "zh-HK": "zh-TW",
+  "pt-BR": "pt",
+  he: "iw",
+  no: "no",
+};
+
+function toGoogleLang(code) {
+  if (!code) return "auto";
+  if (langMap[code]) return langMap[code];
+  // Strip any region suffix Google doesn't recognise (e.g. "en-GB" -> "en")
+  return code.split("-")[0];
+}
+
+export default async function handler(req) {
+  return GET(req);
+}
+
+export async function GET(req) {
+  const url = new URL(req.url);
+  const text = url.searchParams.get("text");
+  const from = url.searchParams.get("from") || "auto";
+  const to = url.searchParams.get("to") || "en";
+
+  if (!text) {
+    return new Response(
+      JSON.stringify({ error: "Text parameter is required" }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+
+  try {
+    const sourceLang = from === "auto" ? "auto" : toGoogleLang(from);
+    const targetLang = toGoogleLang(to);
+
+    // Call Google Translate API directly
+    const translateUrl = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${sourceLang}&tl=${targetLang}&hl=${targetLang}&dt=t&dt=bd&dj=1&source=icon&q=${encodeURIComponent(
+      text
+    )}`;
+
+    const response = await fetch(translateUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Translation API returned ${response.status}`);
+    }
+
+    const data = await response.json();
+
+    // Extract translated text from response
+    let translatedText = "";
+    if (data.sentences && data.sentences.length > 0) {
+      translatedText = data.sentences.map((s) => s.trans).join("");
+    } else if (Array.isArray(data) && data[0] && Array.isArray(data[0])) {
+      translatedText = data[0].map((item) => item[0]).join("");
+    }
+
+    return new Response(
+      JSON.stringify({
+        input: text,
+        output: translatedText || text,
+        from: data.src || from,
+        to,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  } catch (error) {
+    console.error("Translation error:", error);
+    return new Response(
+      JSON.stringify({
+        error: "Translation failed",
+        message: error.message,
+      }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  }
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+
+const STORAGE_KEY = "xcstrings-online-data";
 
 export default function Home() {
   const languages = [
@@ -475,6 +477,28 @@ export default function Home() {
   const [selectedLanguage, setSelectedLanguage] = useState("en");
   const [data, setData] = useState(sampleData);
 
+  // Load previously auto-saved data from local storage on mount.
+  // Kept in useEffect (not useState initializer) to avoid SSR hydration mismatch.
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        setData(JSON.parse(saved));
+      }
+    } catch (e) {
+      console.error("Failed to load saved data from local storage:", e);
+    }
+  }, []);
+
+  // Auto-save data to local storage whenever it changes (temporary safeguard).
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    } catch (e) {
+      console.error("Failed to auto-save data to local storage:", e);
+    }
+  }, [data]);
+
   function importData() {
     const fileInput = document.createElement("input");
     fileInput.type = "file";
@@ -507,7 +531,7 @@ export default function Home() {
           {/* Reset Button */}
           <button
             className="bg-white border border-gray-300/25 rounded-lg p-2 shadow-md dark:bg-gray-900/50 dark:hover:bg-gray-900"
-            onClick={() => { setData(sampleData); alert("Data has been reset.") }}
+            onClick={() => { localStorage.removeItem(STORAGE_KEY); setData(sampleData); alert("Data has been reset.") }}
           >
             Reset
           </button>

--- a/app/page.js
+++ b/app/page.js
@@ -476,6 +476,7 @@ export default function Home() {
 
   const [selectedLanguage, setSelectedLanguage] = useState("en");
   const [data, setData] = useState(sampleData);
+  const [isTranslating, setIsTranslating] = useState(false);
 
   // Load previously auto-saved data from local storage on mount.
   // Kept in useEffect (not useState initializer) to avoid SSR hydration mismatch.
@@ -514,6 +515,62 @@ export default function Home() {
     fileInput.click();
   }
 
+  // Translate every key from the source language into the currently
+  // selected language using the Google Translate endpoint (/api/translate).
+  async function translateAll() {
+    const sourceLanguage = data.sourceLanguage || "en";
+    if (selectedLanguage === sourceLanguage) {
+      alert(
+        "The selected language is the source language. Pick a different language to translate into."
+      );
+      return;
+    }
+
+    setIsTranslating(true);
+    try {
+      const keys = Object.keys(data.strings);
+      const results = await Promise.all(
+        keys.map(async (key) => {
+          const sourceText =
+            data.strings[key].localizations[sourceLanguage]?.stringUnit?.value ||
+            key;
+          try {
+            const res = await fetch(
+              `/api/translate?text=${encodeURIComponent(
+                sourceText
+              )}&from=${sourceLanguage}&to=${selectedLanguage}`
+            );
+            const json = await res.json();
+            return { key, value: json.output ?? null };
+          } catch (e) {
+            console.error(`Failed to translate "${key}":`, e);
+            return { key, value: null };
+          }
+        })
+      );
+
+      const newData = { ...data, strings: { ...data.strings } };
+      for (const { key, value } of results) {
+        if (value == null) continue;
+        const stringEntry = { ...newData.strings[key] };
+        const localizations = { ...stringEntry.localizations };
+        localizations[selectedLanguage] = {
+          ...(localizations[selectedLanguage] || {}),
+          stringUnit: {
+            ...(localizations[selectedLanguage]?.stringUnit || {}),
+            state: "translated",
+            value,
+          },
+        };
+        stringEntry.localizations = localizations;
+        newData.strings[key] = stringEntry;
+      }
+      setData(newData);
+    } finally {
+      setIsTranslating(false);
+    }
+  }
+
   function exportData() {
     // Save data JSON as .xcstrings file
     const element = document.createElement("a");
@@ -544,7 +601,17 @@ export default function Home() {
             Import
           </button>
 
-          <span class="flex-1 text-center">
+          {/* Translate All Button */}
+          <button
+            className="bg-white border border-gray-300/25 rounded-lg p-2 shadow-md dark:bg-gray-900/50 dark:hover:bg-gray-900 disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={translateAll}
+            disabled={isTranslating}
+            title={`Translate all keys into ${languages.find((l) => l.code === selectedLanguage)?.name || selectedLanguage}`}
+          >
+            {isTranslating ? "Translating…" : "✨ Translate"}
+          </button>
+
+          <span className="flex-1 text-center">
             <code className="font-mono font-bold">XCStrings</code> Online
           </span>
 

--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 const STORAGE_KEY = "xcstrings-online-data";
 
@@ -477,6 +477,7 @@ export default function Home() {
   const [selectedLanguage, setSelectedLanguage] = useState("en");
   const [data, setData] = useState(sampleData);
   const [isTranslating, setIsTranslating] = useState(false);
+  const hasLoadedFromStorageRef = useRef(false);
 
   // Load previously auto-saved data from local storage on mount.
   // Kept in useEffect (not useState initializer) to avoid SSR hydration mismatch.
@@ -488,17 +489,45 @@ export default function Home() {
       }
     } catch (e) {
       console.error("Failed to load saved data from local storage:", e);
+    } finally {
+      hasLoadedFromStorageRef.current = true;
     }
   }, []);
 
   // Auto-save data to local storage whenever it changes (temporary safeguard).
   useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-    } catch (e) {
-      console.error("Failed to auto-save data to local storage:", e);
-    }
+    if (!hasLoadedFromStorageRef.current) return;
+
+    const timeoutId = setTimeout(() => {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      } catch (e) {
+        console.error("Failed to auto-save data to local storage:", e);
+      }
+    }, 300);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, [data]);
+
+  async function translateText(sourceText, sourceLanguage) {
+    const res = await fetch("/api/translate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: sourceText,
+        from: sourceLanguage,
+        to: selectedLanguage,
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Translation request failed with status ${res.status}`);
+    }
+
+    return res.json();
+  }
 
   function importData() {
     const fileInput = document.createElement("input");
@@ -529,45 +558,60 @@ export default function Home() {
     setIsTranslating(true);
     try {
       const keys = Object.keys(data.strings);
-      const results = await Promise.all(
-        keys.map(async (key) => {
-          const sourceText =
-            data.strings[key].localizations[sourceLanguage]?.stringUnit?.value ||
-            key;
-          try {
-            const res = await fetch(
-              `/api/translate?text=${encodeURIComponent(
-                sourceText
-              )}&from=${sourceLanguage}&to=${selectedLanguage}`
-            );
-            const json = await res.json();
-            return { key, value: json.output ?? null };
-          } catch (e) {
-            console.error(`Failed to translate "${key}":`, e);
-            return { key, value: null };
-          }
-        })
-      );
+      const results = [];
+      const batchSize = 10;
 
-      const newData = { ...data, strings: { ...data.strings } };
-      for (const { key, value } of results) {
-        if (value == null) continue;
-        const stringEntry = { ...newData.strings[key] };
-        const localizations = { ...stringEntry.localizations };
-        localizations[selectedLanguage] = {
-          ...(localizations[selectedLanguage] || {}),
-          stringUnit: {
-            ...(localizations[selectedLanguage]?.stringUnit || {}),
-            state: "translated",
-            value,
-          },
-        };
-        stringEntry.localizations = localizations;
-        newData.strings[key] = stringEntry;
+      for (let i = 0; i < keys.length; i += batchSize) {
+        const batchKeys = keys.slice(i, i + batchSize);
+        const batchResults = await Promise.all(
+          batchKeys.map(async (key) => {
+            const sourceText =
+              data.strings[key].localizations[sourceLanguage]?.stringUnit?.value ||
+              key;
+            try {
+              const json = await translateText(sourceText, sourceLanguage);
+              return { key, value: json.output ?? null };
+            } catch (e) {
+              console.error(`Failed to translate "${key}":`, e);
+              return { key, value: null };
+            }
+          })
+        );
+        results.push(...batchResults);
       }
-      setData(newData);
+
+      setData((prevData) => {
+        const newData = { ...prevData, strings: { ...prevData.strings } };
+        for (const { key, value } of results) {
+          if (value == null || !newData.strings[key]) continue;
+          const stringEntry = { ...newData.strings[key] };
+          const localizations = { ...stringEntry.localizations };
+          localizations[selectedLanguage] = {
+            ...(localizations[selectedLanguage] || {}),
+            stringUnit: {
+              ...(localizations[selectedLanguage]?.stringUnit || {}),
+              state: "translated",
+              value,
+            },
+          };
+          stringEntry.localizations = localizations;
+          newData.strings[key] = stringEntry;
+        }
+        return newData;
+      });
     } finally {
       setIsTranslating(false);
+    }
+  }
+
+  function resetData() {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch (e) {
+      console.error("Failed to clear saved data from local storage:", e);
+    } finally {
+      setData(sampleData);
+      alert("Data has been reset.");
     }
   }
 
@@ -588,7 +632,7 @@ export default function Home() {
           {/* Reset Button */}
           <button
             className="bg-white border border-gray-300/25 rounded-lg p-2 shadow-md dark:bg-gray-900/50 dark:hover:bg-gray-900"
-            onClick={() => { localStorage.removeItem(STORAGE_KEY); setData(sampleData); alert("Data has been reset.") }}
+            onClick={resetData}
           >
             Reset
           </button>


### PR DESCRIPTION
## Summary

Implements two open feature requests:

- **Auto-save to localStorage** (closes #1) — editor data is persisted to browser local storage automatically so work is not lost if the browser is closed unintentionally.
- **One-click AI/Google Translate** (closes #2) — translate every string into the selected language with one button.

## Changes

### Auto-save (#1)
- Load previously auto-saved data from `localStorage` on mount (via `useEffect` to avoid SSR hydration mismatch; falls back to sample data when nothing is saved).
- Auto-save `data` to `localStorage` on every change.
- Reset button now clears the saved copy before restoring the sample data.
- All storage access is wrapped in `try/catch` so failures degrade gracefully.

### Translate (#2)
- New `app/api/translate/route.js` edge route that proxies the Google Translate web endpoint (`translate.googleapis.com/translate_a/single`), mirroring the implementation used in the 1998media nextJS15 site.
- New **✨ Translate** button that translates every key from the source language into the currently selected language and marks each entry as `translated`.
- Xcode String Catalog language codes (`zh-Hans`, `zh-Hant`, `zh-HK`, `pt-BR`, …) are mapped to Google Translate codes.

## Testing

- `npm run build` passes; `/api/translate` is registered as a dynamic route.
- Verified the endpoint end-to-end against a running server: `Continue` (en→fr) → `Continuer`, `History` (en→zh-Hant) → `歷史`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139YDNJpUzoR3SUqMmBjDYN